### PR TITLE
Add Support for Custom Optimization Solvers in fhs and rollcast Functions

### DIFF
--- a/R/fhs.R
+++ b/R/fhs.R
@@ -45,7 +45,8 @@
 #' garch
 
 fhs <- function(x, p = 0.975, model = c("EWMA", "GARCH"), lambda = 0.94,
-                nboot = NULL, ...) {
+                nboot = NULL, solver = c("nlminb", "solnp", "lbfgs", "gosolnp", "nloptr", "hybrid"),
+                solver.control = list(), ...) {
   if (length(x) <= 1 || any(is.na(x)) || !is.numeric(x)) {
     stop("A numeric vector of length > 1 and without NAs must be passed to",
          " 'x'.")
@@ -78,7 +79,8 @@ fhs <- function(x, p = 0.975, model = c("EWMA", "GARCH"), lambda = 0.94,
   n <- length(x)
   if (model == "GARCH") {
     spec <- do.call(what = rugarch::ugarchspec, args = dots)
-    fit <- rugarch::ugarchfit(data = x, spec = spec)
+    fit <- rugarch::ugarchfit(data = x, spec = spec, solver = solver,
+                              solver.control = solver.control)
     csig <- as.numeric(rugarch::sigma(fit))
     one.ahead.csig <-
       as.numeric(rugarch::sigma(rugarch::ugarchforecast(fit, n.ahead = 1)))

--- a/R/rollcast.R
+++ b/R/rollcast.R
@@ -128,6 +128,8 @@ rollcast <- function(x, p = 0.975,
                      nboot = NULL,
                      smoothscale = c("none", "lpr", "auto"),
                      smoothopts = list(),
+                     solver.control = list(),
+                     solver = c("nlminb", "solnp", "lbfgs", "gosolnp", "nloptr", "hybrid"),
                      ...) {
 
     if (length(x) <= 1 || any(is.na(x)) || !is.numeric(x)) {
@@ -245,7 +247,8 @@ rollcast <- function(x, p = 0.975,
                fcastfun <- fhs
                funargs <- list(x = xcast, p = p,
                                lambda = lambda, nboot = nboot,
-                               model = model, ...)
+                               model = model, solver = solver,
+                               solver.control = solver.control, ...)
                 }
            )
 


### PR DESCRIPTION
Implemented additional optimization solver options (solver = c("nlminb", "solnp", "lbfgs", "gosolnp", "nloptr", "hybrid")) and a solver.control argument for enhanced flexibility in fhs and rollcast functions. This update allows users to specify solvers and control parameters to better suit their needs for robust GARCH model fitting and forecasting.